### PR TITLE
Estructura de carpetas y archivos a Ignorar

### DIFF
--- a/Reservas_Labs/.gitignore
+++ b/Reservas_Labs/.gitignore
@@ -1,0 +1,11 @@
+# NetBeans specific #
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+
+# Class Files #
+*.class

--- a/Reservas_Labs/src/Controladores/Informacion.txt
+++ b/Reservas_Labs/src/Controladores/Informacion.txt
@@ -1,0 +1,1 @@
+En este directorio se deberan crear archivo que se relacionen con el nombre del mismo

--- a/Reservas_Labs/src/Librerias/Informacion.txt
+++ b/Reservas_Labs/src/Librerias/Informacion.txt
@@ -1,0 +1,1 @@
+En este directorio se deberan crear archivo que se relacionen con el nombre del mismo

--- a/Reservas_Labs/src/Modelos/Informacion.txt
+++ b/Reservas_Labs/src/Modelos/Informacion.txt
@@ -1,0 +1,1 @@
+En este directorio se deberan crear archivo que se relacionen con el nombre del mismo

--- a/Reservas_Labs/src/Vista/Informacion.txt
+++ b/Reservas_Labs/src/Vista/Informacion.txt
@@ -1,0 +1,1 @@
+En este directorio se deberan crear archivo que se relacionen con el nombre del mismo

--- a/Reservas_Labs/src/imagenes/Informacion.txt
+++ b/Reservas_Labs/src/imagenes/Informacion.txt
@@ -1,0 +1,1 @@
+En este directorio se deberan crear archivo que se relacionen con el nombre del mismo


### PR DESCRIPTION
Se actualizaron las reglas de ignorar archivos en el archivo .gitignore para excluir determinados archivos del seguimiento en un proyecto Java desarrollado en NetBeans. Además, se agregó la estructura de carpetas Modelo-Vista-Controlador (MVC) en el directorio src, junto con las carpetas imágenes y Librerías.